### PR TITLE
Changes I had to make

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+touch /entrypoint.executing
+
 # if command starts with an option, prepend mysqld
 if [ "${1:0:1}" = '-' ]; then
 	CMDARG="$@"
@@ -34,9 +36,11 @@ fi
 		mysqld --user=mysql --datadir="$DATADIR" --skip-networking &
 		pid="$!"
 
+		sleep 10
+
 		mysql=( mysql --protocol=socket -uroot )
 
-		for i in {30..0}; do
+		for i in $(seq 30 0); do
 			if echo 'SELECT 1' | "${mysql[@]}" &> /dev/null; then
 				break
 			fi
@@ -283,6 +287,7 @@ nohup /report_status.sh root $MYSQL_ROOT_PASSWORD $CLUSTER_NAME $TTL $DISCOVERY_
 
 # set IP address based on the primary interface
 sed -i "s|WSREP_NODE_ADDRESS|$ipaddr|g" /etc/my.cnf
+sed -i "s|XTRABACKUP_PASSWORD|$XTRABACKUP_PASSWORD|g" /etc/my.cnf
 
 echo
 echo >&2 ">> Starting mysqld process"
@@ -294,5 +299,8 @@ if [ -z $cluster_join ]; then
 else
 	export _WSREP_NEW_CLUSTER=''
 fi
+
+# give mysqld some time to start, signal that we have finished executing this script and actual liveness checking can commence
+bash -c "sleep 3; rm /entrypoint.executing"&
 
 exec mysqld --wsrep_cluster_name=$CLUSTER_NAME --wsrep-cluster-address="gcomm://$cluster_join" --wsrep_sst_auth="xtrabackup:$XTRABACKUP_PASSWORD" $_WSREP_NEW_CLUSTER $CMDARG

--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -1,107 +1,43 @@
 #!/bin/bash
-# This script checks if a database container is healthy based on cluster type.
-# The purpose of this script is to make Docker capable of monitoring different
-# database cluster type properly.
-# This script will just return exit 0 (OK) or 1 (NOT OK).
 
-MYSQL_HOST="localhost"
-MYSQL_PORT="3306"
-MYSQL_USERNAME='root'
-MYSQL_PASSWORD=$MYSQL_ROOT_PASSWORD
-MYSQL_OPTS="-N -q -A --connect-timeout=10"
-TMP_FILE="/dev/shm/mysqlchk.$$.out"
-ERR_FILE="/dev/shm/mysqlchk.$$.err"
-FORCE_FAIL="/dev/shm/proxyoff"
-MYSQL_BIN='/usr/bin/mysql'
-CHECK_QUERY="show global status where variable_name='wsrep_local_state'"
-CHECK_QUERY2="show global variables where variable_name='wsrep_sst_method'"
-CHECK_QUERY3="show global variables where variable_name='read_only'"
-CHECK_QUERY4="show global status where variable_name='wsrep_local_state_comment'"
+if [[ -f /entrypoint.executing ]]; then
+  exit 0
+fi
+
+STATE_QUERY="SHOW GLOBAL STATUS WHERE variable_name='wsrep_local_state_comment'"
+
 READINESS=0
 LIVENESS=0
 
 # Kubernetes' readiness & liveness flag
-if [ ! -z $1 ]; then
-	[ $1 == "--readiness" ] && READINESS=1
-	[ $1 == "--liveness" ] && LIVENESS=1
-fi
-
-preflight_check()
-{
-    for I in "$TMP_FILE" "$ERR_FILE"; do
-        if [ -f "$I" ]; then
-            if [ ! -w $I ]; then
-                echo -e "HTTP/1.1 503 Service Unavailable\r\n"
-                echo -e "Content-Type: Content-Type: text/plain\r\n"
-                echo -e "\r\n"
-                echo -e "Cannot write to $I\r\n"
-                echo -e "\r\n"
-                exit 1
-            fi
-        fi
-    done
-}
-return_ok()
-{
-    exit 0
-}
-return_fail()
-{
-    exit 1
-}
-
-preflight_check
-
-if [ -f "$FORCE_FAIL" ]; then
-        echo "$FORCE_FAIL found" > $ERR_FILE
-        return_fail
-fi
-status=$($MYSQL_BIN $MYSQL_OPTS --host=$MYSQL_HOST --port=$MYSQL_PORT --user=$MYSQL_USERNAME --password=$MYSQL_PASSWORD -e "$CHECK_QUERY;" 2>/dev/null | awk '{print $2;}')
-if [ $? -ne 0 ]; then
-        return_fail
-fi
-
-if [ $READINESS -eq 1 ]; then
-	# A node is ready when it reaches Synced
-	if [ $status -eq 4 ]; then
-		readonly=$($MYSQL_BIN $MYSQL_OPTS --host=$MYSQL_HOST --port=$MYSQL_PORT --user=$MYSQL_USERNAME --password=$MYSQL_PASSWORD -e "$CHECK_QUERY3;" 2>/dev/null | awk '{print $2;}')
-                if [ $? -ne 0 ]; then
-                        return_fail
-                fi
-
-                if [ "$readonly" = "YES" -o "$readonly" = "ON" ]; then
-                        return_fail
-                fi
-		return_ok
-	fi
-elif [ $LIVENESS -eq 1 ]; then
-	# A node is alive if it's not in Initialized state
-	comment_status=$($MYSQL_BIN $MYSQL_OPTS --host=$MYSQL_HOST --port=$MYSQL_PORT --user=$MYSQL_USERNAME --password=$MYSQL_PASSWORD -e "$CHECK_QUERY4;" 2>/dev/null | awk '{print $2;}')
-	if [ $comment_status != "Initialized" ]; then
-		return_ok
-	fi
+if [[ ! -z $1 ]]; then
+	[[ $1 == "--readiness" ]] && READINESS=1
+	[[ $1 == "--liveness" ]] && LIVENESS=1
 else
-	if [ $status -eq 2 ] || [ $status -eq 4 ] ; then
-		readonly=$($MYSQL_BIN $MYSQL_OPTS --host=$MYSQL_HOST --port=$MYSQL_PORT --user=$MYSQL_USERNAME --password=$MYSQL_PASSWORD -e "$CHECK_QUERY3;" 2>/dev/null | awk '{print $2;}')
-		if [ $? -ne 0 ]; then
-			return_fail
-		fi
-
-		if [ "$readonly" = "YES" -o "$readonly" = "ON" ]; then
-        		return_fail
-		fi
-
-		if [ $status -eq 2 ]; then
-        		method=$($MYSQL_BIN $MYSQL_OPTS --host=$MYSQL_HOST --port=$MYSQL_PORT --user=$MYSQL_USERNAME --password=$MYSQL_PASSWORD -e "$CHECK_QUERY2;" 2>/dev/null | awk '{print $2;}')
-			if [ $? -ne 0 ]; then
-				return_fail
-        		fi
-			if [ -z "$method" ] || [ "$method" = "rsync" ] || [ "$method" = "mysqldump" ]; then
-				return_fail
-        		fi
-		fi
-
-		return_ok
-	fi
+  LIVENESS=1
 fi
-return_fail
+
+# state == Initialized --> fail all checks
+# state == Synced --> succeed all checks
+# anything else: alive, but not ready
+
+# explanation of state variable:
+# see http://galeracluster.com/documentation-webpages/monitoringthecluster.html
+# "When the node is part of the Primary Component, the typical return values are Joining, Waiting on SST, Joined, Synced or Donor. In the event that the node is part of a nonoperational component, the return value is Initialized."
+# "If the node returns any value other than the one listed here, the state comment is momentary and transient. Check the status variable again for an update."
+
+state=$(mysql --skip-column-names --quick --no-auto-rehash --connect-timeout=10 --protocol=socket --user=root --password="$MYSQL_ROOT_PASSWORD" -e "$STATE_QUERY;" 2>/dev/null | awk '{print $2;}')
+if [[ $? != 0 || -z "$state" ]]; then
+  echo "1 -- command failed or state empty: $state"
+  exit 1
+fi
+if [[ "$state" == "Initialized" ]]; then
+  echo "1 -- $state"
+  exit 1
+fi
+if [[ "$state" == "Synced" ]]; then
+  echo "0 -- $state"
+  exit 0
+fi
+echo $READINESS
+exit $READINESS

--- a/my.cnf
+++ b/my.cnf
@@ -19,6 +19,6 @@ wsrep_on			= ON
 wsrep_provider			= /usr/lib64/galera/libgalera_smm.so
 wsrep_node_address		= WSREP_NODE_ADDRESS
 wsrep_sst_method		= xtrabackup-v2
-wsrep_sst_auth			= "root:"
+wsrep_sst_auth			= "root:XTRABACKUP_PASSWORD"
 
 !includedir /etc/my.cnf.d

--- a/swarm.Dockerfile
+++ b/swarm.Dockerfile
@@ -19,6 +19,8 @@ RUN chmod a+x /usr/bin/jq
 
 EXPOSE 3306 4567 4568
 ONBUILD RUN yum update -y
+HEALTHCHECK --interval=10s --timeout=3s --retries=15 \
+	CMD /bin/sh /healthcheck.sh || exit 1
 
 ENTRYPOINT ["/entrypoint.sh"]
 


### PR DESCRIPTION
Hi there,

this is not meant as a proper PR, but rather as a way of showing you the changes I needed to make for me to be able to get the MariaDB Galera cluster up and running on my Kube 1.7.x cluster, based on your repo here and your blog article.

Thanks a lot for that, they helped a lot in getting started.

Below is the commit message that explains some of the changes. It's actually a bit inaccurate though (I'm noticing only now; have squashed lots of commits), since I've actually done a full rewrite of the healthcheck.sh script based on the Galera Cluster spec and what the docs say how to tell the current node status.

```
- remove HEALTHCHECK instruction from main Dockerfile as that conflicts
  with Kubernetes health and liveness probes; added a swarm.Dockerfile
  that still contains that instruction
- fix XTRABACKUP_PASSWORD handling from env to my.cnf
- optimized healthcheck.sh to work with local mysql instance and connect
  through socket, because that's what we're dealing with here
- also fixed minor formatting issues in that script
```

This is not in production for me yet, but it's soon going to be.

Cheers,
Denis