### PR TITLE
Added AWS storageclass examples

### DIFF
--- a/example-kubernetes/README.md
+++ b/example-kubernetes/README.md
@@ -26,7 +26,20 @@ $ kubectl create -f mariadb-rs.yml
 
 **StatefulSet**
 
-For StatefulSet with persistent storage, start with creating the PVs and PVCs:
+If running on AWS ([kops](https://github.com/kubernetes/kops)), start by creating the storage class ```slow``` or ```standard```. It is possible if different peformance is desired to create a storage class of ones own choice. Please refer to [Kubernetes documentation on persistent disk](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#aws)  
+
+```bash
+$ kubectl create -f ./aws/storage-class-standard.yml
+```
+A Persistent Volume Claim doesn't need to be created and all that needs to be done is to uncomment the line with ```storageClassName``` specified. 
+
+```yml
+      storageClassName: standard
+```
+
+-OR-
+
+If not utilizing a storage class on AWS, and with StatefulSet with persistent storage, start with creating the PVs and PVCs:
 
 ```bash
 $ kubectl create -f mariadb-pv.yml

--- a/example-kubernetes/mariadb-ss.yml
+++ b/example-kubernetes/mariadb-ss.yml
@@ -70,6 +70,9 @@ spec:
       name: mysql-datadir
     spec:
       accessModes: [ "ReadWriteOnce" ]
+      # uncomment if using slow storageClass on AWS
+      # then no need for running pv or pvc manifests
+      storageClassName: slow
       resources:
         requests:
           storage: 10Gi

--- a/example-kubernetes/storage-class-slow.yaml
+++ b/example-kubernetes/storage-class-slow.yaml
@@ -1,0 +1,8 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: slow
+provisioner: kubernetes.io/aws-ebs
+parameters:
+  type: io1
+  iopsPerGB: "10"

--- a/example-kubernetes/storage-class-standard.yaml
+++ b/example-kubernetes/storage-class-standard.yaml
@@ -1,0 +1,7 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: standard 
+provisioner: kubernetes.io/aws-ebs
+parameters:
+  type: gp2 


### PR DESCRIPTION
Hi there!  I am preparing for KubeCon 2017 and am going to use your great example, which is a great improvement over my simple example in https://github.com/kubernetes/kubernetes/tree/master/examples/storage/mysql-galera. I was trying to get it to run on AWS (Kops) and the PV/PVC bits weren't working. I simply used my storage class setup and it worked without having to explicitly create PV/PVC. So, I decided to contribute :)